### PR TITLE
Parsed Description column

### DIFF
--- a/2017/may/sample_description_field.html
+++ b/2017/may/sample_description_field.html
@@ -1,0 +1,79 @@
+<html xmlns:fo="http://www.w3.org/1999/XSL/Format" xmlns:msxsl="urn:schemas-microsoft-com:xslt">
+	<head>
+		<META http-equiv="Content-Type" content="text/html">
+		<meta http-equiv="content-type" content="text/html; charset=UTF-8">
+	</head>
+	<body style="margin:0px 0px 0px 0px;overflow:auto;background:#FFFFFF;">
+		<table style="font-family:Arial,Verdana,Times;font-size:12px;text-align:left;width:100%;border-collapse:collapse;padding:3px 3px 3px 3px">
+			<tr style="text-align:center;font-weight:bold;background:#9CBCE2">
+				<td>I</td>
+			</tr>
+			<tr>
+				<td>
+					<table style="font-family:Arial,Verdana,Times;font-size:12px;text-align:left;width:100%;border-spacing:0px; padding:3px 3px 3px 3px">
+						<tr>
+							<td>GISOBJID</td>
+							<td>10002675</td>
+						</tr>
+						<tr bgcolor="#D4E4F3">
+							<td>POLE_TYPE</td>
+							<td>2in Pipe</td>
+						</tr>
+						<tr>
+							<td>INSTL_TYPE</td>
+							<td>Socket</td>
+						</tr>
+						<tr bgcolor="#D4E4F3">
+							<td>SIGN_FACE1</td>
+							<td>TSSBR7-24X30</td>
+						</tr>
+						<tr>
+							<td>SIGN_DIR1</td>
+							<td>West</td>
+						</tr>
+						<tr bgcolor="#D4E4F3">
+							<td>SIGN_FACE2</td>
+							<td>TSSBR10R</td>
+						</tr>
+						<tr>
+							<td>SIGN_DIR2</td>
+							<td>North</td>
+						</tr>
+						<tr bgcolor="#D4E4F3">
+							<td>SIGN_FACE3</td>
+							<td>&lt;Null&gt;</td>
+						</tr>
+						<tr>
+							<td>SIGN_DIR3</td>
+							<td>&lt;Null&gt;</td>
+						</tr>
+						<tr bgcolor="#D4E4F3">
+							<td>SIGN_FACE4</td>
+							<td>&lt;Null&gt;</td>
+						</tr>
+						<tr>
+							<td>SIGN_DIR4</td>
+							<td>&lt;Null&gt;</td>
+						</tr>
+						<tr bgcolor="#D4E4F3">
+							<td>SIGN_FACE5</td>
+							<td>&lt;Null&gt;</td>
+						</tr>
+						<tr>
+							<td>SIGN_DIR5</td>
+							<td>&lt;Null&gt;</td>
+						</tr>
+						<tr bgcolor="#D4E4F3">
+							<td>SHAPE</td>
+							<td>Point</td>
+						</tr>
+						<tr>
+							<td>SHAPE_FID</td>
+							<td>14</td>
+						</tr>
+					</table>
+				</td>
+			</tr>
+		</table>
+	</body>
+</html>


### PR DESCRIPTION
The "Description" column contains html/xml data.
All rows contain the same set of fields.
Using a text editor, I manually stripped the HTML (via multiple search & replace all commands) to generate individual columns for each field.
The "StreetSigns_PARSED.csv" file replaces the Description column with the individual field colmns
The "sample_description_field.html" file contains the raw data from one row's Description field, with line breaks and tabs added for readability.